### PR TITLE
fix typo

### DIFF
--- a/docs/src/content/components/barqode-stream.md
+++ b/docs/src/content/components/barqode-stream.md
@@ -29,7 +29,7 @@ The `BarqodeStream` component continuously scans frames from a camera stream and
 	}
 
 	function onDetect(detectedCodes: DetectedBarcode[]) {
-		result = detectedCode.map((code) => detectedCode.rawValue).join(", ");
+		result = detectedCodes.map((detectedCode) => detectedCode.rawValue).join(", ");
 	}
 
 	function track(detectedCodes: DetectedBarcode[], ctx: CanvasRenderingContext2D) {


### PR DESCRIPTION
This is a correction for a simple typo.

I've also changed it to `detectedCode` instead of `code` to be consistent with the other examples.