### PR TITLE
Allow to customize zxing-wasm location

### DIFF
--- a/packages/barqode/CHANGELOG.md
+++ b/packages/barqode/CHANGELOG.md
@@ -1,5 +1,15 @@
 # barqode
 
+## 0.1.0
+
+### Minor Changes
+
+- expose `prepareZXingModule` from `zxing-wasm` (See https://github.com/Sec-ant/zxing-wasm#configuring-wasm-serving)
+
+### Patch Changes
+
+- update `barcode-detector` to `v3.0.8`
+
 ## 0.0.2
 
 ### Patch Changes

--- a/packages/barqode/package.json
+++ b/packages/barqode/package.json
@@ -60,7 +60,7 @@
 		}
 	],
 	"dependencies": {
-		"barcode-detector": "^2.3.1",
+		"barcode-detector": "^3.0.8",
 		"runed": "^0.16.1",
 		"webrtc-adapter": "^9.0.1"
 	}

--- a/packages/barqode/src/lib/components/types.ts
+++ b/packages/barqode/src/lib/components/types.ts
@@ -1,4 +1,4 @@
-import type { BarcodeFormat, DetectedBarcode, Point2D } from "barcode-detector/pure";
+import type { BarcodeFormat, DetectedBarcode, Point2D } from "barcode-detector/ponyfill";
 import type { Snippet } from "svelte";
 import type { HTMLInputAttributes } from "svelte/elements";
 

--- a/packages/barqode/src/lib/index.ts
+++ b/packages/barqode/src/lib/index.ts
@@ -7,3 +7,7 @@ export type {
 	DropzoneProps,
 	StreamProps,
 } from "./components/types.js";
+
+// Re-exporing to allow wasm path customization
+// See https://github.com/Sec-ant/zxing-wasm#configuring-wasm-serving
+export { prepareZXingModule } from "barcode-detector/ponyfill";

--- a/packages/barqode/src/lib/internal/scanner.ts
+++ b/packages/barqode/src/lib/internal/scanner.ts
@@ -1,7 +1,7 @@
 // based on vue-qrcode-reader by Niklas Gruhn
 // see https://github.com/gruhn/vue-qrcode-reader
 
-import { type DetectedBarcode, type BarcodeFormat, BarcodeDetector } from "barcode-detector/pure";
+import { type DetectedBarcode, type BarcodeFormat, BarcodeDetector } from "barcode-detector/ponyfill";
 import { eventOn } from "./callforth.js";
 import { DropImageFetchError } from "./errors.js";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,8 +117,8 @@ importers:
   packages/barqode:
     dependencies:
       barcode-detector:
-        specifier: ^2.3.1
-        version: 2.3.1
+        specifier: ^3.0.8
+        version: 3.0.8(@types/emscripten@1.39.13)
       runed:
         specifier: ^0.16.1
         version: 0.16.1(svelte@5.4.0)
@@ -1165,9 +1165,6 @@ packages:
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
-  '@types/dom-webcodecs@0.1.11':
-    resolution: {integrity: sha512-yPEZ3z7EohrmOxbk/QTAa0yonMFkNkjnVXqbGb7D4rMr+F1dGQ8ZUFxXkyLLJuiICPejZ0AZE9Rrk9wUCczx4A==}
-
   '@types/emscripten@1.39.13':
     resolution: {integrity: sha512-cFq+fO/isvhvmuP/+Sl4K4jtU6E23DoivtbO4r50e3odaxAiVdbfSYRDdJ4gCdxx+3aRjhphS5ZMwIH4hFy/Cw==}
 
@@ -1337,8 +1334,8 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  barcode-detector@2.3.1:
-    resolution: {integrity: sha512-D9KEtrquS1tmBZduxBZl8qublIKnRrFqD8TAHDYcLCyrHQBo+vitIxmjMJ61LvXjXyAMalOlO7q0Oh/9Rl2PbQ==}
+  barcode-detector@3.0.8:
+    resolution: {integrity: sha512-Z9jzzE8ngEDyN9EU7lWdGgV07mcnEQnrX8W9WecXDqD2v+5CcVjt9+a134a5zb+kICvpsrDx6NYA6ay4LGFs8A==}
 
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
@@ -2858,6 +2855,10 @@ packages:
     resolution: {integrity: sha512-2I/mjD8cXDpKfdfUK+T6yo/OzugMXIm8lhyJUFM5F/gICMYnkl3C/+4cOSpia8TqpDsi6Qfm5+fdmBNMNmaf2g==}
     engines: {node: '>=18'}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tailwind-merge@2.5.5:
     resolution: {integrity: sha512-0LXunzzAZzo0tEPxV3I297ffKZPlKDrjj7NXphC8V5ak9yHC5zRmxnOe2m/Rd/7ivsOMJe3JZ2JVocoDdQTRBA==}
 
@@ -2924,6 +2925,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-fest@5.4.4:
+    resolution: {integrity: sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw==}
+    engines: {node: '>=20'}
 
   typescript-eslint@8.17.0:
     resolution: {integrity: sha512-409VXvFd/f1br1DCbuKNFqQpXICoTB+V51afcwG1pn1a3Cp92MqAUges3YjwEdQ0cMUoCIodjVDAYzyD8h3SYA==}
@@ -3121,8 +3126,10 @@ packages:
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  zxing-wasm@1.3.4:
-    resolution: {integrity: sha512-9l0QymyATF19FmI92QHe7Dayb+BUN7P7zFAt5iDgTnUf0dFWokz6GVA/W9EepjW5q8s3e89fIE/7uxpX27yqEQ==}
+  zxing-wasm@2.2.4:
+    resolution: {integrity: sha512-1gq5zs4wuNTs5umWLypzNNeuJoluFvwmvjiiT3L9z/TMlVveeJRWy7h90xyUqCe+Qq0zL0w7o5zkdDMWDr9aZA==}
+    peerDependencies:
+      '@types/emscripten': '>=1.39.6'
 
 snapshots:
 
@@ -4032,8 +4039,6 @@ snapshots:
     dependencies:
       '@types/ms': 0.7.34
 
-  '@types/dom-webcodecs@0.1.11': {}
-
   '@types/emscripten@1.39.13': {}
 
   '@types/estree-jsx@1.0.5':
@@ -4205,10 +4210,11 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  barcode-detector@2.3.1:
+  barcode-detector@3.0.8(@types/emscripten@1.39.13):
     dependencies:
-      '@types/dom-webcodecs': 0.1.11
-      zxing-wasm: 1.3.4
+      zxing-wasm: 2.2.4(@types/emscripten@1.39.13)
+    transitivePeerDependencies:
+      - '@types/emscripten'
 
   better-path-resolve@1.0.0:
     dependencies:
@@ -6118,6 +6124,8 @@ snapshots:
       magic-string: 0.30.14
       zimmerframe: 1.1.2
 
+  tagged-tag@1.0.0: {}
+
   tailwind-merge@2.5.5: {}
 
   tailwind-variants@0.3.0(tailwindcss@4.0.0-beta.4):
@@ -6172,6 +6180,10 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-fest@5.4.4:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typescript-eslint@8.17.0(eslint@9.16.0(jiti@2.4.1))(typescript@5.7.2):
     dependencies:
@@ -6371,6 +6383,7 @@ snapshots:
 
   zwitch@2.0.4: {}
 
-  zxing-wasm@1.3.4:
+  zxing-wasm@2.2.4(@types/emscripten@1.39.13):
     dependencies:
       '@types/emscripten': 1.39.13
+      type-fest: 5.4.4


### PR DESCRIPTION
`zxing-wasm` allows [customizing the location from which the `wasm` assets are served, via the `prepareZXingModule` function](https://github.com/Sec-ant/zxing-wasm#configuring-wasm-serving), for example to serve it from your own server, rather than a CDN.

This PR proposes to expose that function to `barqode` users.